### PR TITLE
for jsdoc3/jsdoc3.github.com#5 - mention jsdoc/util/error in plugin docs

### DIFF
--- a/Jake/articles/about-plugins
+++ b/Jake/articles/about-plugins
@@ -48,6 +48,9 @@
                 </a></li>
             </ol>
           </li>
+          <li><a href="#throwing-errors">Throwing Errors
+            </a>
+          </li>
         </ol>
       </li>
       <li><a href="#packaging-jsdoc-3-plugins">Packaging JSDoc 3 Plugins
@@ -535,6 +538,21 @@ function isInWidgetFactory(node, depth) {
 
 <p>
     Lastly, the visitors are executed in the order the plugins are listed in the conf.json file. A plugin can stop later plugins from visiting a node by setting a <code>stopPropagation</code> property on the event object (e.stopPropagation = true). A plugin can stop the event from firing setting a <code>preventDefault</code> property.
+</p>
+
+<h3 name="throwing-errors" id="throwing-errors">
+    Throwing Errors
+</h3>
+<p>
+    If you wish your plugin to throw an error, do it using the <code>handle</code> function in the <code>jsdoc/util/error</code> module.
+</p>
+
+{{#example}}Example
+require('jsdoc/util/error').handle( new Error('I do not like green eggs and ham!') );
+{{/example}}
+
+<p>
+    By default this will throw the error, halting the execution of <code>jsdoc</code>. However, if the user used the <code>--lenient</code> switch when they ran <code>jsdoc</code> it will simply log the error to the console and continue.
 </p>
 
 <h2 name="packaging-jsdoc-3-plugins" id="packaging-jsdoc-3-plugins">

--- a/about-plugins.html
+++ b/about-plugins.html
@@ -221,6 +221,9 @@
                 </a></li>
             </ol>
           </li>
+          <li><a href="#throwing-errors">Throwing Errors
+            </a>
+          </li>
         </ol>
       </li>
       <li><a href="#packaging-jsdoc-3-plugins">Packaging JSDoc 3 Plugins
@@ -753,6 +756,25 @@ function isInWidgetFactory(node, depth) {
 
 <p>
     Lastly, the visitors are executed in the order the plugins are listed in the conf.json file. A plugin can stop later plugins from visiting a node by setting a <code>stopPropagation</code> property on the event object (e.stopPropagation = true). A plugin can stop the event from firing setting a <code>preventDefault</code> property.
+</p>
+
+<h3 name="throwing-errors" id="throwing-errors">
+    Throwing Errors
+</h3>
+<p>
+    If you wish your plugin to throw an error, do it using the <code>handle</code> function in the <code>jsdoc/util/error</code> module.
+</p>
+
+<dl class="example">
+<dt>Example</dt>
+<dd>
+<pre class="prettyprint lang-js">
+require('jsdoc/util/error').handle( new Error('I do not like green eggs and ham!') );
+
+</pre>
+</dd>
+</dl><p>
+    By default this will throw the error, halting the execution of <code>jsdoc</code>. However, if the user used the <code>--lenient</code> switch when they ran <code>jsdoc</code> it will simply log the error to the console and continue.
 </p>
 
 <h2 name="packaging-jsdoc-3-plugins" id="packaging-jsdoc-3-plugins">


### PR DESCRIPTION
For jsdoc3/jsdoc3.github.com#5.

There is a counterpart pull request in jsdoc3/jsdoc#311.
