### PR TITLE
tags-access: showcase implicit public access

### DIFF
--- a/content/en/tags-access.md
+++ b/content/en/tags-access.md
@@ -56,8 +56,7 @@ function OtherThingy() {
 
     /** @protected */
     this._bar = 1;
-
-    /** @public */
+    
     this.pez = 2;
 
 }


### PR DESCRIPTION
Hi,

Removing the @public tag in the comparative example could make sense as it would demonstrate the implicit access (that is, public).

What do you think about that change?