### PR TITLE
fix a wrong link

### DIFF
--- a/content/en/tags-param.md
+++ b/content/en/tags-param.md
@@ -22,7 +22,7 @@ The parameter type can be a built-in JavaScript type, such as `string` or `Objec
 [JSDoc namepath][namepath] to another symbol in your code. If you have written documentation for the
 symbol at that namepath, JSDoc will automatically link to the documentation for that symbol. You can
 also use a type expression to indicate, for example, that a parameter is not nullable or can accept
-any type; see the [`@type` tag documentation][tags-type] for details.
+any type; see the [`@type` tag documentation][type-tag] for details.
 
 If you provide a description, you can make the JSDoc comment more readable by inserting a hyphen
 before the description. Be sure to include a space before and after the hyphen.

--- a/tags-param.html
+++ b/tags-param.html
@@ -70,7 +70,7 @@
     <p>The parameter type can be a built-in JavaScript type, such as <code>string</code> or <code>Object</code>, or a
       <a href="about-namepaths.html">JSDoc namepath</a> to another symbol in your code. If you have written documentation for the symbol at that namepath, JSDoc
       will automatically link to the documentation for that symbol. You can also use a type expression to indicate, for example, that a parameter is not nullable
-      or can accept any type; see the [<code>@type</code> tag documentation][tags-type] for details.</p>
+      or can accept any type; see the <a href="tags-type.html"><code>@type</code> tag documentation</a> for details.</p>
     <p>If you provide a description, you can make the JSDoc comment more readable by inserting a hyphen before the description. Be sure to include a space before and
       after the hyphen.</p>
     <h2 id="examples">Examples</h2>


### PR DESCRIPTION
Document ID defined in bottom of md file:

```
[type-tag]: tags-type.html
```

but placed ID is mismatched like `[tags-type]`.