### PR TITLE
Typo in index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
       <dt><a href="tags-alias.html">@alias</a></dt>
       <dd>Treat a member as if it had a different name.</dd>
       <dt><a href="tags-augments.html">@augments</a> (synonyms: @extends)</dt>
-      <dd>Indicate that a symbol inherits from, ands adds to, a parent symbol.</dd>
+      <dd>Indicate that a symbol inherits from, and adds to, a parent symbol.</dd>
       <dt><a href="tags-author.html">@author</a></dt>
       <dd>Identify the author of an item.</dd>
       <dt><a href="tags-borrows.html">@borrows</a></dt>


### PR DESCRIPTION
`ands` -> `and`