### PR TITLE
Fix @constant example

### DIFF
--- a/content/en/tags-constant.md
+++ b/content/en/tags-constant.md
@@ -28,10 +28,11 @@ declarations.
 {% example "A string constant representing the color red" %}
 
 ```js
-/** @constant
-    @type {string}
-    @default
-*/
+/**
+ *  @constant
+ *  @type {string}
+ *  @default
+ */
 const RED = 'FF0000';
 
 /** @constant {number} */


### PR DESCRIPTION
There were missing asterisks at the beginning of a few lines, and I moved the tag itself to the second line, in keeping with the style of other JSDoc tags.