### PR TITLE
Update GitHub links in about-configuring-jsdoc

### DIFF
--- a/about-configuring-jsdoc.html
+++ b/about-configuring-jsdoc.html
@@ -80,7 +80,7 @@ module.exports = {
 </code></pre>
     </figure>
     <p>For a more comprehensive example of a JSON configuration file, see the file
-      <a href="https://github.com/jsdoc3/jsdoc/blob/master/conf.json.EXAMPLE"><code>conf.json.EXAMPLE</code></a>.</p>
+      <a href="https://github.com/jsdoc/jsdoc/tree/main/packages/jsdoc/conf.json.EXAMPLE"><code>conf.json.EXAMPLE</code></a>.</p>
     <h2 id="default-configuration-options">Default configuration options</h2>
     <p>If you do not specify a configuration file, JSDoc uses the following configuration options:</p>
     <figure>
@@ -136,7 +136,7 @@ module.exports = {
 </code></pre>
     </figure>
     <p>See the <a href="about-plugins.html">plugin reference</a> for further information, and look in <a
-        href="https://github.com/jsdoc3/jsdoc/tree/master/plugins">JSDoc&#39;s <code>plugins</code>
+        href="https://github.com/jsdoc/jsdoc/tree/main/packages/jsdoc/plugins">JSDoc&#39;s <code>plugins</code>
         directory</a> for the plugins built into JSDoc.</p>
     <p>You can configure the Markdown plugin by adding a <code>markdown</code> object to your configuration file. See
       <a href="plugins-markdown.html">Configuring the Markdown Plugin</a> for details.</p>
@@ -343,7 +343,7 @@ module.exports = {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/content/en/about-configuring-jsdoc.md
+++ b/content/en/about-configuring-jsdoc.md
@@ -48,7 +48,7 @@ For a more comprehensive example of a JSON configuration file, see the file
 [`conf.json.EXAMPLE`][conf-json-example].
 
 [about-commandline]: about-commandline.html
-[conf-json-example]: https://github.com/jsdoc3/jsdoc/blob/master/conf.json.EXAMPLE
+[conf-json-example]: https://github.com/jsdoc/jsdoc/tree/main/packages/jsdoc/conf.json.EXAMPLE
 [markdown]: plugins-markdown.html
 
 
@@ -127,7 +127,7 @@ directory][jsdoc-plugins] for the plugins built into JSDoc.
 You can configure the Markdown plugin by adding a `markdown` object to your configuration file. See
 [Configuring the Markdown Plugin][markdown] for details.
 
-[jsdoc-plugins]: https://github.com/jsdoc3/jsdoc/tree/master/plugins
+[jsdoc-plugins]: https://github.com/jsdoc/jsdoc/tree/main/packages/jsdoc/plugins
 [markdown]: plugins-markdown.html
 [plugins]: about-plugins.html
 


### PR DESCRIPTION
Changed link paths from `jsdoc3/jsdoc/*/master/*` to `jsdoc/jsdoc/tree/main/packages/jsdoc/*`.

Fixed https://github.com/jsdoc/jsdoc/issues/1982