### PR TITLE
fix: a whole bunch of `&lt;` where `<` should be

### DIFF
--- a/content/howto-es2015-modules.md
+++ b/content/howto-es2015-modules.md
@@ -74,7 +74,7 @@ export {
      * Get the red, green, and blue values of a color.
      * @function
      * @param {string} color - A color, in hexadecimal format.
-     * @returns {Array.&lt;number>} An array of the red, green, and blue values,
+     * @returns {Array.<number>} An array of the red, green, and blue values,
      * each ranging from 0 to 255.
      */
     rgbify as toRgb

--- a/content/tags-author.md
+++ b/content/tags-author.md
@@ -25,7 +25,7 @@ address to a `mailto:` link.
 
 ```js
 /**
- * @author Jane Smith &lt;jsmith@example.com>
+ * @author Jane Smith <jsmith@example.com>
  */
 function MyClass() {}
 ```

--- a/content/tags-example.md
+++ b/content/tags-example.md
@@ -40,7 +40,7 @@ Examples can also be captioned using `<caption></caption>` after the @example ta
 ```js
 /**
  * Solves equations of the form a * x = b
- * @example &lt;caption>Example usage of method1.&lt;/caption>
+ * @example <caption>Example usage of method1.</caption>
  * // returns 2
  * globalNS.method1(5, 10);
  * @returns {Number} Returns the value of x for the equation.

--- a/content/tags-implements.md
+++ b/content/tags-implements.md
@@ -43,7 +43,7 @@ function Color() {}
  * Get the color as an array of red, green, and blue values, represented as
  * decimal numbers between 0 and 1.
  *
- * @returns {Array&lt;number>} An array containing the red, green, and blue values,
+ * @returns {Arraynumber>} An array containing the red, green, and blue values,
  * in that order.
  */
 Color.prototype.rgb = function() {
@@ -67,7 +67,7 @@ TransparentColor.prototype.rgb = function() {
  * Get the color as an array of red, green, blue, and alpha values, represented
  * as decimal numbers between 0 and 1.
  *
- * @returns {Array&lt;number>} An array containing the red, green, blue, and alpha
+ * @returns {Array<number>} An array containing the red, green, blue, and alpha
  * values, in that order.
  */
 TransparentColor.prototype.rgba = function() {

--- a/content/tags-inline-link.md
+++ b/content/tags-inline-link.md
@@ -76,9 +76,9 @@ By default, the example above produces output similar to the following:
 ::: example "Output for {@link} tags"
 
 ```html
-See &lt;a href="MyClass.html">MyClass&lt;/a> and &lt;a href="MyClass.html#foo">MyClass's foo
-property&lt;/a>. Also, check out &lt;a href="http://www.google.com">Google&lt;/a> and
-&lt;a href="https://github.com">GitHub&lt;/a>.
+See <a href="MyClass.html">MyClass</a> and <a href="MyClass.html#foo">MyClass's foo
+property</a>. Also, check out <a href="http://www.google.com">Google</a> and
+<a href="https://github.com">GitHub</a>.
 ```
 :::
 
@@ -88,8 +88,8 @@ produce the following output:
 ::: example "Output with clever links enabled"
 
 ```html
-See &lt;a href="MyClass.html">&lt;code>MyClass&lt;/code>&lt;/a> and &lt;a href="MyClass.html#foo">
-&lt;code>MyClass's foo property&lt;/code>&lt;/a>. Also, check out
-&lt;a href="http://www.google.com">Google&lt;/a> and &lt;a href="https://github.com">GitHub&lt;/a>.
+See <a href="MyClass.html"><code>MyClass</code></a> and <a href="MyClass.html#foo">
+<code>MyClass's foo property</code></a>. Also, check out
+<a href="http://www.google.com">Google</a> and <a href="https://github.com">GitHub</a>.
 ```
 :::

--- a/content/tags-inline-tutorial.md
+++ b/content/tags-inline-tutorial.md
@@ -49,9 +49,9 @@ Started," the example above produces output similar to the following:
 ::: example "Output for {@link} tags"
 
 ```html
-See &lt;a href="tutorial-gettingstarted.html">Getting Started&lt;/a> and
-&lt;a href="tutorial-dashboard.html">Configuring the Dashboard&lt;/a>.
-For more information, see &lt;a href="tutorial-create.html">Creating a Widget&lt;/a> and
-&lt;a href="tutorial-destroy.html">Destroying a Widget&lt;/a>.
+See <a href="tutorial-gettingstarted.html">Getting Started</a> and
+<a href="tutorial-dashboard.html">Configuring the Dashboard</a>.
+For more information, see <a href="tutorial-create.html">Creating a Widget</a> and
+<a href="tutorial-destroy.html">Destroying a Widget</a>.
 ```
 :::

--- a/content/tags-interface.md
+++ b/content/tags-interface.md
@@ -57,7 +57,7 @@ function Color() {}
  * Get the color as an array of red, green, and blue values, represented as
  * decimal numbers between 0 and 1.
  *
- * @returns {Array&lt;number>} An array containing the red, green, and blue values,
+ * @returns {Array<number>} An array containing the red, green, and blue values,
  * in that order.
  */
 Color.prototype.rgb = function() {
@@ -84,7 +84,7 @@ The following example uses virtual comments, rather than code, to define the `Co
  *
  * @function
  * @name Color#rgb
- * @returns {Array&lt;number>} An array containing the red, green, and blue values,
+ * @returns {Array<number>} An array containing the red, green, and blue values,
  * in that order.
  */
 ```

--- a/content/tags-param.md
+++ b/content/tags-param.md
@@ -234,7 +234,7 @@ function sayHello(somebody) {
  */
 function sum(num) {
     var i = 0, n = arguments.length, t = 0;
-    for (; i &lt; n; i++) {
+    for (; i < n; i++) {
         t += arguments[i];
     }
     return t;

--- a/content/tags-type.md
+++ b/content/tags-type.md
@@ -220,7 +220,7 @@ documented.
  */
 function sum(num) {
     var i=0, n=arguments.length, t=0;
-    for (; i&lt;n; i++) {
+    for (; i < n; i++) {
         t += arguments[i];
     }
     return t;


### PR DESCRIPTION
Fixes #263 

On multiple markdown pages there were HTML-escaped `<` characters when it was clear that the literal character was intended. This results in the documentation pages showing `&lt;` in the browser where `<` is what is meant to be shown, which happens because markdown already HTML-escapes special characters seen in code blocks.

It is suspected (by me) that a previous markdown renderer with a bug was used and using `&lt;` in place of `<` was a workaround, then later the markdown previewer used was changed and nobody noticed this issue.