### PR TITLE
Fix @callback page tags

### DIFF
--- a/content/tags-callback.md
+++ b/content/tags-callback.md
@@ -1,6 +1,6 @@
 ---
 tag: callback
-tags: blockTagss
+tags: blockTags
 description: Document a callback function.
 related:
 - /tags-function


### PR DESCRIPTION
The frontmatter in `tags-callback.md` had `tags: blockTagss` instead of `tags: blockTags`, which prevented the [@callback page](https://jsdoc.app/tags-callback) from appearing on the homepage under the **Block tags** section.

Merging this will resolve issue https://github.com/jsdoc/jsdoc.github.io/issues/244.

A screenshot of fix from this branch is included below, with the change highlighted for emphasis.

<img width="1331" height="702" alt="Screenshot of homepage with @callback function included" src="https://github.com/user-attachments/assets/eec43f71-b678-4edd-9340-d044a894f86a" />
